### PR TITLE
Add gpu resource management and scheduling into hadoop yarn.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.classification.InterfaceStability;
  * <code>df</code>. It also offers facilities to gate commands by 
  * time-intervals.
  */
-@InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce"})
+@InterfaceAudience.LimitedPrivate({"HDFS", "MapReduce", "YARN"})
 @InterfaceStability.Unstable
 abstract public class Shell {
   

--- a/hadoop-tools/hadoop-gridmix/src/test/java/org/apache/hadoop/mapred/gridmix/DummyResourceCalculatorPlugin.java
+++ b/hadoop-tools/hadoop-gridmix/src/test/java/org/apache/hadoop/mapred/gridmix/DummyResourceCalculatorPlugin.java
@@ -105,4 +105,71 @@ public class DummyResourceCalculatorPlugin extends ResourceCalculatorPlugin {
   public float getCpuUsage() {
     return getConf().getFloat(CPU_USAGE, -1);
   }
+
+  /**
+   * Obtain the number of GPUs of the machine.
+   *
+   * @return GPU number
+   */
+  @Override
+  public int getGpuCount() {
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU name by GPU id.
+   *
+   * @param gpuId
+   * @return GPU name
+   */
+  @Override
+  public String getGpuName(int gpuId) {
+    return null;
+  }
+
+  /**
+   * Obtain the GPU total memory by GPU id.
+   *
+   * @param gpuId
+   * @return GPU total memory
+   */
+  @Override
+  public int getGpuTotalMemoryInMb(int gpuId) {
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU used memory by GPU id.
+   *
+   * @param gpuId
+   * @return GPU used memory
+   */
+  @Override
+  public int getGpuUsedMemoryInMb(int gpuId) {
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU free memory by GPU id.
+   *
+   * @param gpuId
+   * @return GPU free memory
+   */
+  @Override
+  public int getGpuFreeMemoryInMb(int gpuId) {
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU compute capacity by GPU id.
+   *
+   * @param gpuId
+   * @return GPU computing capacity
+   */
+  @Override
+  public int getGpuUtilization(int gpuId) {
+    return 0;
+  }
+
+
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/Gpu.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/Gpu.java
@@ -1,0 +1,75 @@
+package org.apache.hadoop.yarn.api.records;
+
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.hadoop.classification.InterfaceStability.Stable;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.yarn.util.Records;
+
+@Public
+@Unstable
+public abstract class Gpu {
+
+  @Public
+  @Stable
+  public static Gpu newInstance(int id, String name, int totalMemoryInMb,
+                                int usedMemoryInMb, int freeMemoryInMb,
+                                int utilizationGpu) {
+    Gpu gpu = Records.newRecord(Gpu.class);
+    gpu.setId(id);
+    gpu.setName(name);
+    gpu.setTotalMemoryInMb(totalMemoryInMb);
+    gpu.setUsedMemoryInMb(usedMemoryInMb);
+    gpu.setFreeMemoryInMb(freeMemoryInMb);
+    gpu.setUtilizationGpu(utilizationGpu);
+    return gpu;
+  }
+
+  @Public
+  @Unstable
+  public abstract void setId(int id);
+
+  @Public
+  @Unstable
+  public abstract int getId();
+
+  @Public
+  @Unstable
+  public abstract void setName(String name);
+
+  @Public
+  @Unstable
+  public abstract String getName();
+
+  @Public
+  @Unstable
+  public abstract void setTotalMemoryInMb(int totalMemoryInMb);
+
+  @Public
+  @Unstable
+  public abstract int getTotalMemoryInMb();
+
+  @Public
+  @Unstable
+  public abstract void setUsedMemoryInMb(int usedMemoryInMb);
+
+  @Public
+  @Unstable
+  public abstract int getUsedMemoryInMb();
+
+  @Public
+  @Unstable
+  public abstract void setFreeMemoryInMb(int freeMemoryInMb);
+
+  @Public
+  @Unstable
+  public abstract int getFreeMemoryInMb();
+
+  @Public
+  @Unstable
+  public abstract void setUtilizationGpu(int utilizationGpu);
+
+  @Public
+  @Unstable
+  public abstract int getUtilizationGpu();
+
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/Resource.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/Resource.java
@@ -21,8 +21,12 @@ package org.apache.hadoop.yarn.api.records;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.classification.InterfaceStability.Stable;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.util.Records;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * <p><code>Resource</code> models a set of computer resources in the 
@@ -54,9 +58,16 @@ public abstract class Resource implements Comparable<Resource> {
   @Public
   @Stable
   public static Resource newInstance(int memory, int vCores) {
+    return newInstance(memory, vCores, new ArrayList<Gpu>());
+  }
+
+  @Public
+  @Unstable
+  public static Resource newInstance(int memory, int vCores, List<Gpu> gpus) {
     Resource resource = Records.newRecord(Resource.class);
     resource.setMemory(memory);
     resource.setVirtualCores(vCores);
+    resource.setGpus(gpus);
     return resource;
   }
 
@@ -105,33 +116,28 @@ public abstract class Resource implements Comparable<Resource> {
   @Evolving
   public abstract void setVirtualCores(int vCores);
 
-  @Override
-  public int hashCode() {
-    final int prime = 263167;
-    int result = 3571;
-    result = 939769357 + getMemory(); // prime * result = 939769357 initially
-    result = prime * result + getVirtualCores();
-    return result;
-  }
+  /**
+   * Get <em>list of gpu</em> of the resource.
+   *
+   * GPU is a new computing unit with massive computing cores. It could be used
+   * to accelerate a lot of apps.
+   *
+   * @return <em>the list of gpu </em> of the resource
+   */
+  @Public
+  @Evolving
+  public abstract List<Gpu> getGpus();
 
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (!(obj instanceof Resource))
-      return false;
-    Resource other = (Resource) obj;
-    if (getMemory() != other.getMemory() || 
-        getVirtualCores() != other.getVirtualCores()) {
-      return false;
-    }
-    return true;
-  }
+  /**
+   * Set <em>list of gpu</em> of the resource.
+   *
+   * GPU is a new computing unit with massive computing cores. It could be used
+   * to accelerate a lot of apps.
+   *
+   * @param gpus <em>the list of gpu </em> of the resource
+   */
+  @Public
+  @Evolving
+  public abstract void setGpus(List<Gpu> gpus);
 
-  @Override
-  public String toString() {
-    return "<memory:" + getMemory() + ", vCores:" + getVirtualCores() + ">";
-  }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -816,7 +816,11 @@ public class YarnConfiguration extends Configuration {
   public static final String YARN_TRACKING_URL_GENERATOR = 
       YARN_PREFIX + "tracking.url.generator";
 
-  /** Amount of memory in GB that can be allocated for containers.*/
+  /** The number of GPUs that can be allocated for containers.*/
+  public static final String NM_GPU_NUMBER = NM_PREFIX + "resource.gpu-number";
+  public static final int DEFAULT_NM_GPU_NUMBER = 0;
+
+  /** Amount of memory in MB that can be allocated for containers.*/
   public static final String NM_PMEM_MB = NM_PREFIX + "resource.memory-mb";
   public static final int DEFAULT_NM_PMEM_MB = 8 * 1024;
 
@@ -825,7 +829,7 @@ public class YarnConfiguration extends Configuration {
       + "pmem-check-enabled";
   public static final boolean DEFAULT_NM_PMEM_CHECK_ENABLED = true;
 
-  /** Specifies whether physical memory check is enabled. */
+  /** Specifies whether virtual memory check is enabled. */
   public static final String NM_VMEM_CHECK_ENABLED = NM_PREFIX
       + "vmem-check-enabled";
   public static final boolean DEFAULT_NM_VMEM_CHECK_ENABLED = true;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_protos.proto
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-api/src/main/proto/yarn_protos.proto
@@ -53,9 +53,19 @@ message ContainerIdProto {
   optional int64 id = 3;
 }
 
+message GpuProto {
+  optional int32 id = 1;
+  optional string name = 2;
+  optional int32 total_memory_in_mb = 3;
+  optional int32 used_memory_in_mb = 4;
+  optional int32 free_memory_in_mb = 5;
+  optional int32 utilization_gpu = 6;
+}
+
 message ResourceProto {
   optional int32 memory = 1;
   optional int32 virtual_cores = 2;
+  repeated GpuProto gpus = 3;
 }
 
 message ResourceOptionProto {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/GpuPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/GpuPBImpl.java
@@ -1,0 +1,116 @@
+package org.apache.hadoop.yarn.api.records.impl.pb;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.yarn.api.records.Gpu;
+import org.apache.hadoop.yarn.proto.YarnProtos.GpuProto;
+import org.apache.hadoop.yarn.proto.YarnProtos.GpuProtoOrBuilder;
+
+@Private
+@Unstable
+public class GpuPBImpl extends Gpu {
+  GpuProto proto = null;
+  GpuProto.Builder builder = null;
+  boolean viaProto = false;
+
+  public GpuPBImpl() {
+    builder = GpuProto.newBuilder();
+  }
+
+  public GpuPBImpl(GpuProto proto) {
+    this.proto = proto;
+    viaProto = true;
+  }
+
+  public GpuProto getProto() {
+    proto = viaProto ? proto : builder.build();
+    viaProto = true;
+    return proto;
+  }
+
+  private void maybeInitBuilder() {
+    if (viaProto || builder == null) {
+      builder = GpuProto.newBuilder(proto);
+    }
+    viaProto = false;
+  }
+
+  @Override
+  public void setId(int id) {
+    maybeInitBuilder();
+    builder.setId(id);
+  }
+
+  @Override
+  public int getId() {
+    GpuProtoOrBuilder p = viaProto ? proto : builder;
+    return p.getId();
+  }
+
+  @Override
+  public void setName(String name) {
+    maybeInitBuilder();
+    builder.setName(name);
+  }
+
+  @Override
+  public String getName() {
+    GpuProtoOrBuilder p = viaProto ? proto : builder;
+    return p.getName();
+  }
+
+  @Override
+  public void setTotalMemoryInMb(int totalMemoryInMb) {
+    maybeInitBuilder();
+    builder.setTotalMemoryInMb(totalMemoryInMb);
+  }
+
+  @Override
+  public int getTotalMemoryInMb() {
+    GpuProtoOrBuilder p = viaProto ? proto : builder;
+    return p.getTotalMemoryInMb();
+  }
+
+  @Override
+  public void setUsedMemoryInMb(int usedMemoryInMb) {
+    maybeInitBuilder();
+    builder.setUsedMemoryInMb(usedMemoryInMb);
+  }
+
+  @Override
+  public int getUsedMemoryInMb() {
+    GpuProtoOrBuilder p = viaProto ? proto : builder;
+    return p.getUsedMemoryInMb();
+  }
+
+  @Override
+  public void setFreeMemoryInMb(int freeMemoryInMb) {
+    maybeInitBuilder();
+    builder.setFreeMemoryInMb(freeMemoryInMb);
+  }
+
+  @Override
+  public int getFreeMemoryInMb() {
+    GpuProtoOrBuilder p = viaProto ? proto : builder;
+    return p.getFreeMemoryInMb();
+  }
+
+  @Override
+  public void setUtilizationGpu(int utilizationGpu) {
+    maybeInitBuilder();
+    builder.setUtilizationGpu(utilizationGpu);
+  }
+
+  @Override
+  public int getUtilizationGpu() {
+    return builder.getUtilizationGpu();
+  }
+
+  @Override
+  public String toString() {
+    return this.getName() + StringUtils.COMMA_STR + this.getUsedMemoryInMb() + "/"
+        + this.getFreeMemoryInMb() + "/" + this.getTotalMemoryInMb() + StringUtils.COMMA_STR
+        + this.getUtilizationGpu() + "%";
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ResourcePBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ResourcePBImpl.java
@@ -21,9 +21,14 @@ package org.apache.hadoop.yarn.api.records.impl.pb;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.yarn.api.records.Gpu;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.proto.YarnProtos.ResourceProto;
 import org.apache.hadoop.yarn.proto.YarnProtos.ResourceProtoOrBuilder;
+import org.apache.hadoop.yarn.proto.YarnProtos.GpuProto;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Private
 @Unstable
@@ -31,7 +36,9 @@ public class ResourcePBImpl extends Resource {
   ResourceProto proto = ResourceProto.getDefaultInstance();
   ResourceProto.Builder builder = null;
   boolean viaProto = false;
-  
+
+  private List<Gpu> gpus = null;
+
   public ResourcePBImpl() {
     builder = ResourceProto.newBuilder();
   }
@@ -53,7 +60,17 @@ public class ResourcePBImpl extends Resource {
     }
     viaProto = false;
   }
-    
+
+  private void initGpus() {
+    ResourceProtoOrBuilder p = viaProto ? proto : builder;
+    if (gpus != null) {
+      return;
+    }
+    gpus = new ArrayList<>();
+    for (GpuProto gpuProto : p.getGpusList()) {
+      gpus.add(convertFromProtoFormat(gpuProto));
+    }
+  }
   
   @Override
   public int getMemory() {
@@ -80,6 +97,20 @@ public class ResourcePBImpl extends Resource {
   }
 
   @Override
+  public List<Gpu> getGpus() {
+    initGpus();
+    return gpus;
+  }
+
+  @Override
+  public void setGpus(List<Gpu> gpus) {
+    if (null == gpus) {
+      builder.clearGpus();
+    }
+    this.gpus = gpus;
+  }
+
+  @Override
   public int compareTo(Resource other) {
     int diff = this.getMemory() - other.getMemory();
     if (diff == 0) {
@@ -87,6 +118,9 @@ public class ResourcePBImpl extends Resource {
     }
     return diff;
   }
-  
+
+  private GpuPBImpl convertFromProtoFormat(GpuProto p) {
+    return new GpuPBImpl(p);
+  }
   
 }  

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Nvml.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Nvml.java
@@ -1,0 +1,101 @@
+package org.apache.hadoop.yarn.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.util.Shell;
+import org.apache.hadoop.yarn.api.records.Gpu;
+import org.apache.hadoop.yarn.api.records.impl.pb.GpuPBImpl;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class is used to get gpu-related information by "nvidia-smi".
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class Nvml extends Shell {
+
+  private String NVIDIA_SMI = "nvidia-smi";
+
+  private static final String COMMA = org.apache.hadoop.util.StringUtils.COMMA_STR;
+
+  private static final String QUERY_OPTION_ID = "id";
+  private static final String QUERY_OPTION_NAME = "name";
+  private static final String QUERY_OPTION_UTILIZATION_GPU = "utilization.gpu";
+  private static final String QUERY_OPTION_MEMORY_TOTAL = "memory.total";
+  private static final String QUERY_OPTION_MEMORY_USED = "memory.used";
+  private static final String QUERY_OPTION_MEMORY_FREE = "memory.free";
+
+  private static final String FORMAT_OPTION_CSV = "csv";
+  private static final String FORMAT_OPTION_NOUNITS = "nounits";
+
+  private List<Gpu> gpus;
+
+  public Nvml() {
+    if (Shell.WINDOWS) {
+      NVIDIA_SMI = "nvidia-smi.exe";
+    }
+  }
+
+  public List<Gpu> getGpuList() throws IOException {
+    run();
+    return gpus;
+  }
+
+  @Override
+  protected String[] getExecString() {
+    return new String[]{ NVIDIA_SMI,
+        "--query-gpu=" + QUERY_OPTION_ID + COMMA + QUERY_OPTION_NAME + COMMA +
+        QUERY_OPTION_UTILIZATION_GPU + COMMA + QUERY_OPTION_MEMORY_TOTAL + COMMA +
+        QUERY_OPTION_MEMORY_USED + COMMA + QUERY_OPTION_MEMORY_FREE,
+        "--format=" + FORMAT_OPTION_CSV + COMMA + FORMAT_OPTION_NOUNITS };
+  }
+
+  @Override
+  protected void parseExecResult(BufferedReader lines) throws IOException {
+    gpus = null;
+
+    String line = lines.readLine();
+    if (line == null) {
+      throw new IOException("Unable to get gpu status from " + NVIDIA_SMI);
+    }
+    if (line.contains("nvidia-smi: command not found")) {
+      throw new IOException("nvidia-smi command not found.");
+    }
+
+    gpus = new ArrayList<>();
+
+    if (StringUtils.isEmpty(line)) {
+      return;
+    }
+
+    try {
+      while ((line = lines.readLine()) != null) {
+        String[] infos = line.split(COMMA);
+        Gpu gpu = Gpu.newInstance(Integer.parseInt(infos[0].trim()), infos[1].trim(),
+            Integer.parseInt(infos[2].trim()), Integer.parseInt(infos[3].trim()),
+            Integer.parseInt(infos[4].trim()), Integer.parseInt(infos[5].trim()));
+        gpus.add(gpu);
+      }
+    } catch (IndexOutOfBoundsException | NumberFormatException e) {
+      throw new IOException("Unexpected stat output: " + line, e);
+    }
+  }
+
+  public static void main(String args[]) {
+    try {
+      List<Gpu> gpus = new Nvml().getGpuList();
+
+      for (Gpu gpu : gpus) {
+        System.out.print(gpu);
+      }
+
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ResourceCalculatorPlugin.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ResourceCalculatorPlugin.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Shell;
 
+import java.io.IOException;
+
 /**
  * Plugin to calculate resource information on the system.
  *
@@ -90,6 +92,95 @@ public abstract class ResourceCalculatorPlugin extends Configured {
    * @return CPU usage in %
    */
   public abstract float getCpuUsage();
+
+  /**
+   * Obtain the number of GPUs of the machine.
+   *
+   * @return GPU number
+   */
+  public int getGpuCount() {
+    try {
+      return new Nvml().getGpuList().size();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU name by GPU id.
+   *
+   * @param gpuId
+   * @return GPU name
+   */
+  public String getGpuName(int gpuId) {
+    try {
+      return new Nvml().getGpuList().get(gpuId).getName();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  /**
+   * Obtain the GPU total memory by GPU id.
+   *
+   * @param gpuId
+   * @return GPU total memory
+   */
+  public int getGpuTotalMemoryInMb(int gpuId) {
+    try {
+      return new Nvml().getGpuList().get(gpuId).getTotalMemoryInMb();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU used memory by GPU id.
+   *
+   * @param gpuId
+   * @return GPU used memory
+   */
+  public int getGpuUsedMemoryInMb(int gpuId) {
+    try {
+      return new Nvml().getGpuList().get(gpuId).getUsedMemoryInMb();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU free memory by GPU id.
+   *
+   * @param gpuId
+   * @return GPU free memory
+   */
+  public int getGpuFreeMemoryInMb(int gpuId) {
+    try {
+      return new Nvml().getGpuList().get(gpuId).getFreeMemoryInMb();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return 0;
+  }
+
+  /**
+   * Obtain the GPU compute capacity by GPU id.
+   *
+   * @param gpuId
+   * @return GPU computing capacity
+   */
+  public int getGpuUtilization(int gpuId) {
+    try {
+      return new Nvml().getGpuList().get(gpuId).getUtilizationGpu();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return 0;
+  }
 
   /**
    * Create the ResourceCalculatorPlugin from the class name and configure it. If

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/Resources.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/resource/Resources.java
@@ -20,8 +20,11 @@ package org.apache.hadoop.yarn.util.resource;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.yarn.api.records.Gpu;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.util.Records;
+
+import java.util.List;
 
 @InterfaceAudience.LimitedPrivate({"YARN", "MapReduce"})
 @Unstable
@@ -47,6 +50,16 @@ public class Resources {
 
     @Override
     public void setVirtualCores(int cores) {
+      throw new RuntimeException("NONE cannot be modified!");
+    }
+
+    @Override
+    public List<Gpu> getGpus() {
+      return null;
+    }
+
+    @Override
+    public void setGpus(List<Gpu> gpus) {
       throw new RuntimeException("NONE cannot be modified!");
     }
 
@@ -80,6 +93,16 @@ public class Resources {
 
     @Override
     public void setVirtualCores(int cores) {
+      throw new RuntimeException("NONE cannot be modified!");
+    }
+
+    @Override
+    public List<Gpu> getGpus() {
+      return null;
+    }
+
+    @Override
+    public void setGpus(List<Gpu> gpus) {
       throw new RuntimeException("NONE cannot be modified!");
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/NodeStatusUpdaterImpl.java
@@ -43,12 +43,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.service.AbstractService;
 import org.apache.hadoop.util.VersionUtil;
-import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.apache.hadoop.yarn.api.records.ContainerId;
-import org.apache.hadoop.yarn.api.records.ContainerState;
-import org.apache.hadoop.yarn.api.records.ContainerStatus;
-import org.apache.hadoop.yarn.api.records.NodeId;
-import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.*;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.event.Dispatcher;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -70,6 +65,7 @@ import org.apache.hadoop.yarn.server.nodemanager.containermanager.ContainerManag
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.application.ApplicationState;
 import org.apache.hadoop.yarn.server.nodemanager.containermanager.container.Container;
 import org.apache.hadoop.yarn.server.nodemanager.metrics.NodeManagerMetrics;
+import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.YarnVersionInfo;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -148,7 +144,18 @@ public class NodeStatusUpdaterImpl extends AbstractService implements
         conf.getInt(
             YarnConfiguration.NM_VCORES, YarnConfiguration.DEFAULT_NM_VCORES);
 
-    this.totalResource = Resource.newInstance(memoryMb, virtualCores);
+    int gpuNum =
+        conf.getInt(
+            YarnConfiguration.NM_GPU_NUMBER, YarnConfiguration.DEFAULT_NM_GPU_NUMBER);
+
+    List<Gpu> gpuList = new ArrayList<>();
+    for (int i = 0; i < gpuNum; i++) {
+      Gpu gpu = Gpu.newInstance(i, null, 0,
+          0, 0, 0);
+      gpuList.add(gpu);
+    }
+
+    this.totalResource = Resource.newInstance(memoryMb, virtualCores, gpuList);
     metrics.addResource(totalResource);
     this.tokenKeepAliveEnabled = isTokenKeepAliveEnabled(conf);
     this.tokenRemovalDelayMs =

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeInfo.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/dao/NodeInfo.java
@@ -49,6 +49,8 @@ public class NodeInfo {
   protected long availMemoryMB;
   protected long usedVirtualCores;
   protected long availableVirtualCores;
+  protected long usedGpuNum;
+  protected long availableGpuNum;
   protected ArrayList<String> nodeLabels = new ArrayList<String>();
 
   public NodeInfo() {
@@ -131,6 +133,10 @@ public class NodeInfo {
   public long getUsedVirtualCores() {
     return this.usedVirtualCores;
   }
+
+  public long getUsedGpuNum() { return this.usedGpuNum; }
+
+  public long getAvailableGpuNum() { return this.availableGpuNum; }
 
   public long getAvailableVirtualCores() {
     return this.availableVirtualCores;


### PR DESCRIPTION
Changes needed for this pull request:
 
 - NM
   - GPU resource model 
   - Obtain local GPU status
   - Send GPU status to RM
   - Monitor GPU resource
   - Web server to show GPU resource and usage

 - RM
   - Gather all GPU resource
   - GPU resource scheduling
   - Web server to show GPU resource
